### PR TITLE
Revert "comment on missing step"

### DIFF
--- a/docs/module-1.rst
+++ b/docs/module-1.rst
@@ -380,7 +380,7 @@ Part 1. Create a Landsat Mosaic
 |
 
 19. The map now shows the complete mosaic that incorporates all of the user-defined settings.
-?????Either change the screenshot or add a step to click SCN and Use All Scenes?????
+
 .. image:: images/completed_mosaic.JPG
    :alt: The imagery preview with the completed mosaic shown.
    :width: 450


### PR DESCRIPTION
Reverts sig-gis/SEPAL-CEO#14

OK, I understand the comment better now. The screenshot will never match 100% because users might change the scenes, this was the result of me changing the scenes. I'll add a qualifier that this is an example.